### PR TITLE
Refactor: 패키지명을 `auth`에서 `authentication`으로 변경

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/authentication/AuthenticationInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/AuthenticationInterceptor.java
@@ -1,10 +1,10 @@
-package com.uranus.taskmanager.api.auth;
+package com.uranus.taskmanager.api.authentication;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.authentication.exception.UserNotLoggedInException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/uranus/taskmanager/api/authentication/LoginMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/LoginMember.java
@@ -1,11 +1,11 @@
-package com.uranus.taskmanager.api.auth;
+package com.uranus.taskmanager.api.authentication;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LoginRequired {
+public @interface LoginMember {
 }

--- a/src/main/java/com/uranus/taskmanager/api/authentication/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/LoginMemberArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth;
+package com.uranus.taskmanager.api.authentication;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -7,8 +7,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
-import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.exception.UserNotLoggedInException;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;

--- a/src/main/java/com/uranus/taskmanager/api/authentication/LoginRequired.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/LoginRequired.java
@@ -1,11 +1,11 @@
-package com.uranus.taskmanager.api.auth;
+package com.uranus.taskmanager.api.authentication;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.PARAMETER)
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LoginMember {
+public @interface LoginRequired {
 }

--- a/src/main/java/com/uranus/taskmanager/api/authentication/SessionKey.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/SessionKey.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth;
+package com.uranus.taskmanager.api.authentication;
 
 public abstract class SessionKey {
 	public static final String LOGIN_MEMBER = "loginId";

--- a/src/main/java/com/uranus/taskmanager/api/authentication/controller/AuthenticationController.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/controller/AuthenticationController.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.controller;
+package com.uranus.taskmanager.api.authentication.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -7,11 +7,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.uranus.taskmanager.api.auth.LoginRequired;
-import com.uranus.taskmanager.api.auth.SessionKey;
-import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
-import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
-import com.uranus.taskmanager.api.auth.service.AuthenticationService;
+import com.uranus.taskmanager.api.authentication.LoginRequired;
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.dto.response.LoginResponse;
+import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
 import com.uranus.taskmanager.api.common.ApiResponse;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginMemberDto.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginMemberDto.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.dto.request;
+package com.uranus.taskmanager.api.authentication.dto.request;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.dto.request;
+package com.uranus.taskmanager.api.authentication.dto.request;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/response/LoginResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.dto.response;
+package com.uranus.taskmanager.api.authentication.dto.response;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/exception/AuthenticationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/exception/AuthenticationException.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.exception;
+package com.uranus.taskmanager.api.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/exception/InvalidLoginIdentityException.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/exception/InvalidLoginIdentityException.java
@@ -1,8 +1,6 @@
-package com.uranus.taskmanager.api.auth.exception;
+package com.uranus.taskmanager.api.authentication.exception;
 
 import org.springframework.http.HttpStatus;
-
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
 
 public class InvalidLoginIdentityException extends AuthenticationException {
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/exception/InvalidLoginPasswordException.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.exception;
+package com.uranus.taskmanager.api.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/exception/UserNotLoggedInException.java
@@ -1,8 +1,6 @@
-package com.uranus.taskmanager.api.auth.exception;
+package com.uranus.taskmanager.api.authentication.exception;
 
 import org.springframework.http.HttpStatus;
-
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
 
 public class UserNotLoggedInException extends AuthenticationException {
 

--- a/src/main/java/com/uranus/taskmanager/api/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/service/AuthenticationService.java
@@ -1,12 +1,12 @@
-package com.uranus.taskmanager.api.auth.service;
+package com.uranus.taskmanager.api.authentication.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
-import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
-import com.uranus.taskmanager.api.auth.exception.InvalidLoginIdentityException;
-import com.uranus.taskmanager.api.auth.exception.InvalidLoginPasswordException;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.dto.response.LoginResponse;
+import com.uranus.taskmanager.api.authentication.exception.InvalidLoginIdentityException;
+import com.uranus.taskmanager.api.authentication.exception.InvalidLoginPasswordException;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.security.PasswordEncoder;

--- a/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
+import com.uranus.taskmanager.api.authentication.exception.AuthenticationException;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.common.FieldErrorDto;
 import com.uranus.taskmanager.api.invitation.exception.InvitationException;

--- a/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
@@ -7,8 +7,8 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import com.uranus.taskmanager.api.auth.AuthenticationInterceptor;
-import com.uranus.taskmanager.api.auth.LoginMemberArgumentResolver;
+import com.uranus.taskmanager.api.authentication.AuthenticationInterceptor;
+import com.uranus.taskmanager.api.authentication.LoginMemberArgumentResolver;
 import com.uranus.taskmanager.api.workspacemember.authorization.AuthorizationInterceptor;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/uranus/taskmanager/api/invitation/controller/InvitationController.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/controller/InvitationController.java
@@ -5,9 +5,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.uranus.taskmanager.api.auth.LoginMember;
-import com.uranus.taskmanager.api.auth.LoginRequired;
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.LoginMember;
+import com.uranus.taskmanager.api.authentication.LoginRequired;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.invitation.dto.response.InvitationAcceptResponse;
 import com.uranus.taskmanager.api.invitation.service.InvitationService;

--- a/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.invitation.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.dto.response.InvitationAcceptResponse;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.uranus.taskmanager.api.auth.LoginMember;
-import com.uranus.taskmanager.api.auth.LoginRequired;
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.LoginMember;
+import com.uranus.taskmanager.api.authentication.LoginRequired;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
+import com.uranus.taskmanager.api.authentication.exception.AuthenticationException;
 
 public class InvalidWorkspacePasswordException extends AuthenticationException {
 	private static final String MESSAGE = "The given workspace password is invalid";

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.workspace.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -5,7 +5,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateService.java
@@ -1,6 +1,6 @@
 package com.uranus.taskmanager.api.workspace.service;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.CommonException;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptor.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.uranus.taskmanager.api.auth.SessionKey;
-import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.authentication.exception.UserNotLoggedInException;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;

--- a/src/test/java/com/uranus/taskmanager/api/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/authentication/controller/AuthenticationControllerTest.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.controller;
+package com.uranus.taskmanager.api.authentication.controller;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -16,11 +16,11 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uranus.taskmanager.api.auth.SessionKey;
-import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
-import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
-import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
-import com.uranus.taskmanager.api.auth.service.AuthenticationService;
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.dto.response.LoginResponse;
+import com.uranus.taskmanager.api.authentication.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;

--- a/src/test/java/com/uranus/taskmanager/api/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/authentication/service/AuthenticationServiceTest.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.auth.service;
+package com.uranus.taskmanager.api.authentication.service;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
-import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
-import com.uranus.taskmanager.api.auth.exception.InvalidLoginIdentityException;
-import com.uranus.taskmanager.api.auth.exception.InvalidLoginPasswordException;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.dto.response.LoginResponse;
+import com.uranus.taskmanager.api.authentication.exception.InvalidLoginIdentityException;
+import com.uranus.taskmanager.api.authentication.exception.InvalidLoginPasswordException;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;

--- a/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uranus.taskmanager.api.auth.SessionKey;
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.global.config.WebMvcConfig;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.dto.response.InvitationAcceptResponse;

--- a/src/test/java/com/uranus/taskmanager/api/invitation/service/InvitationServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/service/InvitationServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.dto.response.InvitationAcceptResponse;

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.global.config.WebMvcConfig;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.security.PasswordEncoder;

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.exception.InvitationAlreadyExistsException;

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-import com.uranus.taskmanager.api.auth.service.AuthenticationService;
+import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;

--- a/src/test/java/com/uranus/taskmanager/config/TestWebConfig.java
+++ b/src/test/java/com/uranus/taskmanager/config/TestWebConfig.java
@@ -8,8 +8,8 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import com.uranus.taskmanager.api.auth.AuthenticationInterceptor;
-import com.uranus.taskmanager.api.auth.LoginMemberArgumentResolver;
+import com.uranus.taskmanager.api.authentication.AuthenticationInterceptor;
+import com.uranus.taskmanager.api.authentication.LoginMemberArgumentResolver;
 import com.uranus.taskmanager.api.workspacemember.authorization.AuthorizationInterceptor;
 
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/uranus/taskmanager/fixture/RestAssuredAuthenticationFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/RestAssuredAuthenticationFixture.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.fixture;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
 
 import io.restassured.RestAssured;

--- a/src/test/java/com/uranus/taskmanager/fixture/TestFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/TestFixture.java
@@ -1,6 +1,6 @@
 package com.uranus.taskmanager.fixture;
 
-import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.member.domain.Member;


### PR DESCRIPTION
Close #37

## 🚀 설명
- 패키지명을 `auth`에서 `authentication`으로 변경

---
## ✅ 변경 사항
- [x] `auth` -> `authentication`으로 변경

---
## 🚩 관련 이슈, PR
- #37 

---
## 📖 참고