### PR TITLE
add tika magic byte validation

### DIFF
--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jspecify = "1.0.0"
 commonsText = "1.14.0"
 commonsLang3 = "3.18.0"
 commonsCodec = "1.17.2"
+tika = "3.2.2"
 springdocOpenapi = "2.8.16"
 awsSdkS3 = "2.31.1"
 
@@ -62,6 +63,7 @@ jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify"
 commons-text = { group = "org.apache.commons", name = "commons-text", version.ref = "commonsText" }
 commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLang3" }
 commons-codec = { group = "commons-codec", name = "commons-codec", version.ref = "commonsCodec"}
+tika-core = { group = "org.apache.tika", name = "tika-core", version.ref = "tika" }
 
 # API Documentation
 swagger-annotations = { group = "io.swagger.core.v3", name = "swagger-annotations-jakarta", version = "2.2.43" }

--- a/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentPolicyConfig.java
+++ b/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentPolicyConfig.java
@@ -11,9 +11,6 @@ public class AttachmentPolicyConfig {
 
     @Bean
     public IssueAttachmentPolicy issueAttachmentPolicy(AttachmentProperties properties) {
-        return new IssueAttachmentPolicy(
-                properties.getMaxFileSize(),
-                properties.getMaxAttachmentsPerIssue(),
-                properties.getAllowedContentTypes());
+        return new IssueAttachmentPolicy(properties.getMaxAttachmentsPerIssue(), properties.getAllowedContentTypes());
     }
 }

--- a/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentProperties.java
+++ b/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentProperties.java
@@ -10,7 +10,6 @@ public class AttachmentProperties {
 
     private String storageType = "local";
     private String storagePath = "./tissue-storage";
-    private long maxFileSize = 20 * 1024 * 1024; // 20MB
     private int maxAttachmentsPerIssue = 20;
 
     private List<String> allowedContentTypes = List.of(

--- a/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentProperties.java
+++ b/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/config/AttachmentProperties.java
@@ -23,7 +23,12 @@ public class AttachmentProperties {
             "application/json",
             "application/xml",
             "application/zip",
-            "application/gzip");
+            "application/gzip",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/x-hwp",
+            "application/hwp+zip");
 
     private S3 s3 = new S3();
 

--- a/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/web/IssueAttachmentController.java
+++ b/backend/tissue-adapter/src/main/java/com/tissue/feature/attachment/web/IssueAttachmentController.java
@@ -1,6 +1,5 @@
 package com.tissue.feature.attachment.web;
 
-import com.tissue.feature.attachment.application.dto.request.UploadAttachmentCommand;
 import com.tissue.feature.attachment.application.dto.response.AttachmentDetailResponse;
 import com.tissue.feature.attachment.application.dto.response.AttachmentUploadResponse;
 import com.tissue.feature.attachment.application.dto.response.FileDownloadResult;
@@ -14,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -61,13 +59,9 @@ public class IssueAttachmentController {
             @PathVariable String workspaceKey,
             @PathVariable String issueKey,
             @RequestParam("file") MultipartFile file,
-            @CurrentMember MemberDetails memberDetails)
-            throws IOException {
-        UploadAttachmentCommand command = new UploadAttachmentCommand(
-                file.getOriginalFilename(), file.getContentType(), file.getSize(), file.getInputStream());
-
+            @CurrentMember MemberDetails memberDetails) {
         AttachmentUploadResponse response = attachmentCommandUseCase.upload(
-                IssueIdentifier.of(workspaceKey, issueKey), command, memberDetails.getMemberId());
+                IssueIdentifier.of(workspaceKey, issueKey), file, memberDetails.getMemberId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/backend/tissue-core/build.gradle
+++ b/backend/tissue-core/build.gradle
@@ -9,6 +9,7 @@ project(':tissue-core') {
 
     implementation libs.spring.security.crypto
     implementation libs.commons.codec
+    implementation libs.tika.core
 
     api libs.jspecify
     api libs.jackson.databind.nullable

--- a/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/dto/request/UploadAttachmentCommand.java
+++ b/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/dto/request/UploadAttachmentCommand.java
@@ -1,6 +1,0 @@
-package com.tissue.feature.attachment.application.dto.request;
-
-import java.io.InputStream;
-
-public record UploadAttachmentCommand(
-        String originalFilename, String contentType, long fileSize, InputStream inputStream) {}

--- a/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/port/usecase/AttachmentCommandUseCase.java
+++ b/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/port/usecase/AttachmentCommandUseCase.java
@@ -1,12 +1,12 @@
 package com.tissue.feature.attachment.application.port.usecase;
 
-import com.tissue.feature.attachment.application.dto.request.UploadAttachmentCommand;
 import com.tissue.feature.attachment.application.dto.response.AttachmentUploadResponse;
 import com.tissue.shared.dto.IssueIdentifier;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface AttachmentCommandUseCase {
 
-    AttachmentUploadResponse upload(IssueIdentifier iid, UploadAttachmentCommand command, Long memberId);
+    AttachmentUploadResponse upload(IssueIdentifier iid, MultipartFile file, Long memberId);
 
     void delete(IssueIdentifier iid, Long attachmentId, Long memberId);
 }

--- a/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/service/FileContentDetector.java
+++ b/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/service/FileContentDetector.java
@@ -1,0 +1,19 @@
+package com.tissue.feature.attachment.application.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileContentDetector {
+
+    private static final int HEADER_SIZE = 65536;
+
+    private final Tika tika = new Tika();
+
+    public String detect(InputStream inputStream, String filename) throws IOException {
+        byte[] header = inputStream.readNBytes(HEADER_SIZE);
+        return tika.detect(header, filename);
+    }
+}

--- a/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/service/IssueAttachmentCommandService.java
+++ b/backend/tissue-core/src/main/java/com/tissue/feature/attachment/application/service/IssueAttachmentCommandService.java
@@ -2,7 +2,6 @@ package com.tissue.feature.attachment.application.service;
 
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_STORAGE_FAILED;
 
-import com.tissue.feature.attachment.application.dto.request.UploadAttachmentCommand;
 import com.tissue.feature.attachment.application.dto.response.AttachmentUploadResponse;
 import com.tissue.feature.attachment.application.port.repository.AttachmentRepository;
 import com.tissue.feature.attachment.application.port.usecase.AttachmentCommandUseCase;
@@ -17,11 +16,13 @@ import com.tissue.global.filestorage.FileStorageClient;
 import com.tissue.global.filestorage.StoredFile;
 import com.tissue.shared.dto.IssueIdentifier;
 import com.tissue.shared.exception.base.InternalServerException;
+import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -35,22 +36,27 @@ public class IssueAttachmentCommandService implements AttachmentCommandUseCase {
     private final AttachmentAuthorizationService attachmentAuthorizationService;
     private final FileStorageClient fileStorageClient;
     private final IssueAttachmentPolicy attachmentPolicy;
+    private final FileContentDetector fileContentDetector;
 
     @Override
-    public AttachmentUploadResponse upload(IssueIdentifier iid, UploadAttachmentCommand cmd, Long memberId) {
+    public AttachmentUploadResponse upload(IssueIdentifier iid, MultipartFile file, Long memberId) {
         projectMemberFinder.getWithWorkspaceMember(iid.workspaceKey(), iid.projectKey(), memberId);
         Issue issue = issueFinder.getWithProjectBy(iid.workspaceKey(), iid.issueKey());
 
-        attachmentPolicy.ensureFileValid(cmd.fileSize(), cmd.contentType());
+        attachmentPolicy.ensureFileValid(file.getSize(), file.getContentType());
+
+        String detectedContentType = detectAndLogMismatch(file);
+
+        attachmentPolicy.ensureContentTypeAllowed(detectedContentType);
         long currentCount = attachmentRepository.countByIssueKeyAndWorkspaceKey(iid.issueKey(), iid.workspaceKey());
         attachmentPolicy.ensureAttachmentLimit(currentCount);
 
-        String storedFilename = UUID.randomUUID() + extractExtension(cmd.originalFilename());
+        String storedFilename = UUID.randomUUID() + extractExtension(file.getOriginalFilename());
         String directory = iid.workspaceKey() + "/" + iid.issueKey();
 
         StoredFile storedFile;
-        try {
-            storedFile = fileStorageClient.store(directory, storedFilename, cmd.inputStream(), cmd.fileSize());
+        try (var inputStream = file.getInputStream()) {
+            storedFile = fileStorageClient.store(directory, storedFilename, inputStream, file.getSize());
         } catch (Exception e) {
             throw new InternalServerException(ATTACHMENT_STORAGE_FAILED, e);
         }
@@ -58,14 +64,15 @@ public class IssueAttachmentCommandService implements AttachmentCommandUseCase {
         try {
             IssueAttachment attachment = IssueAttachment.create(
                     issue,
-                    cmd.originalFilename(),
+                    file.getOriginalFilename(),
                     storedFilename,
-                    cmd.contentType(),
-                    cmd.fileSize(),
+                    detectedContentType,
+                    file.getSize(),
                     storedFile.storedPath());
             attachmentRepository.save(attachment);
 
-            return new AttachmentUploadResponse(iid.issueKey(), attachment.getId(), cmd.originalFilename());
+            return new AttachmentUploadResponse(iid.issueKey(), attachment.getId(), file.getOriginalFilename());
+
         } catch (Exception e) {
             fileStorageClient.delete(storedFile.storedPath());
             throw e;
@@ -84,6 +91,25 @@ public class IssueAttachmentCommandService implements AttachmentCommandUseCase {
 
         fileStorageClient.delete(attachment.getStoredPath());
         attachmentRepository.delete(attachment);
+    }
+
+    private String detectAndLogMismatch(MultipartFile file) {
+        String detectedContentType;
+        try (var inputStream = file.getInputStream()) {
+            detectedContentType = fileContentDetector.detect(inputStream, file.getOriginalFilename());
+        } catch (IOException e) {
+            throw new InternalServerException(ATTACHMENT_STORAGE_FAILED, e);
+        }
+
+        if (!detectedContentType.equals(file.getContentType())) {
+            log.warn(
+                    "Content type mismatch - declared: {}, detected: {}, file: {}",
+                    file.getContentType(),
+                    detectedContentType,
+                    file.getOriginalFilename());
+        }
+
+        return detectedContentType;
     }
 
     private String extractExtension(String filename) {

--- a/backend/tissue-core/src/main/java/com/tissue/feature/attachment/domain/policy/IssueAttachmentPolicy.java
+++ b/backend/tissue-core/src/main/java/com/tissue/feature/attachment/domain/policy/IssueAttachmentPolicy.java
@@ -2,7 +2,6 @@ package com.tissue.feature.attachment.domain.policy;
 
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_CONTENT_TYPE_NOT_ALLOWED;
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_FILE_EMPTY;
-import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_FILE_SIZE_EXCEEDED;
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_LIMIT_EXCEEDED;
 
 import com.tissue.shared.exception.base.BadRequestException;
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IssueAttachmentPolicy {
 
-    private final long maxFileSize;
     private final int maxAttachmentsPerIssue;
     private final List<String> allowedContentTypes;
 
@@ -20,9 +18,10 @@ public class IssueAttachmentPolicy {
         if (fileSize <= 0) {
             throw new BadRequestException(ATTACHMENT_FILE_EMPTY);
         }
-        if (fileSize > maxFileSize) {
-            throw new BadRequestException(ATTACHMENT_FILE_SIZE_EXCEEDED);
-        }
+        ensureContentTypeAllowed(contentType);
+    }
+
+    public void ensureContentTypeAllowed(String contentType) {
         if (!allowedContentTypes.contains(contentType)) {
             throw new BadRequestException(ATTACHMENT_CONTENT_TYPE_NOT_ALLOWED);
         }

--- a/backend/tissue-core/src/test/java/com/tissue/feature/attachment/domain/policy/IssueAttachmentPolicyTest.java
+++ b/backend/tissue-core/src/test/java/com/tissue/feature/attachment/domain/policy/IssueAttachmentPolicyTest.java
@@ -2,7 +2,6 @@ package com.tissue.feature.attachment.domain.policy;
 
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_CONTENT_TYPE_NOT_ALLOWED;
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_FILE_EMPTY;
-import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_FILE_SIZE_EXCEEDED;
 import static com.tissue.feature.attachment.domain.exception.AttachmentErrorCode.ATTACHMENT_LIMIT_EXCEEDED;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -15,12 +14,10 @@ import org.junit.jupiter.api.Test;
 
 class IssueAttachmentPolicyTest {
 
-    private final long maxFileSize = 10 * 1024 * 1024;
     private final int maxAttachmentsPerIssue = 5;
     private final List<String> allowedContentTypes = List.of("image/png", "image/jpeg", "application/pdf");
 
-    private final IssueAttachmentPolicy policy =
-            new IssueAttachmentPolicy(maxFileSize, maxAttachmentsPerIssue, allowedContentTypes);
+    private final IssueAttachmentPolicy policy = new IssueAttachmentPolicy(maxAttachmentsPerIssue, allowedContentTypes);
 
     @Nested
     @DisplayName("ensure file is valid")
@@ -39,15 +36,6 @@ class IssueAttachmentPolicyTest {
                     .isInstanceOf(BadRequestException.class)
                     .extracting("errorCode")
                     .isEqualTo(ATTACHMENT_FILE_EMPTY);
-        }
-
-        @Test
-        @DisplayName("fail: if file size exceeded, throws BadRequestException")
-        void failFileSizeExceeded() {
-            assertThatThrownBy(() -> policy.ensureFileValid(20 * 1024 * 1024, "image/png"))
-                    .isInstanceOf(BadRequestException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ATTACHMENT_FILE_SIZE_EXCEEDED);
         }
 
         @Test


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Ex: "Added a global exception handler for EntityNotFoundException to return 404 responses."
-->
- add Tika dependency
- use Tika for magic byte validation
- use `Multipart` directly in service
- add upload content type support for office documents and hwp
  - [https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation update

## How Has This Been Tested?

<!--
Please choose the tests that you ran to verify your changes.
-->

- [ ] Unit Test
- [ ] Integration Test
- [ ] E2E Test
- [ ] Manual Test
- Additional context if needed (Optional):

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues or Links

<!-- Please link to the issue here:
- # (issue number) -->
- #395 
