### PR TITLE
remove jjwt and use nimbus (oauth2-resource-server)

### DIFF
--- a/.github/workflows/llm-report.yml
+++ b/.github/workflows/llm-report.yml
@@ -1,0 +1,17 @@
+  name: LLM Report
+  on:
+    pull_request:
+  permissions:
+    contents: read
+    pull-requests: write
+  jobs:
+    llm-report:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0 
+        - uses: kiseki1011/JavaLLMReport@v0.9.0
+          with:
+            scan-path: .            
+            fail-on: SECURITY_PROBLEM

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 springBoot = "3.5.11"
 springDependencyManagement = "1.1.7"
 
-jjwt = "0.12.6"
 jacksonDatabindNullable = "0.2.7"
 jspecify = "1.0.0"
 commonsText = "1.14.0"
@@ -59,11 +58,6 @@ logstash-logback-encoder = { group = "net.logstash.logback", name = "logstash-lo
 
 # Testcontainers
 testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql" }
-
-# JWT
-jjwt-api = { group = "io.jsonwebtoken", name = "jjwt-api", version.ref = "jjwt" }
-jjwt-impl = { group = "io.jsonwebtoken", name = "jjwt-impl", version.ref = "jjwt" }
-jjwt-jackson = { group = "io.jsonwebtoken", name = "jjwt-jackson", version.ref = "jjwt" }
 
 # Common
 jackson-databind-nullable = { group = "org.openapitools", name = "jackson-databind-nullable", version.ref = "jacksonDatabindNullable" }

--- a/backend/tissue-security/build.gradle
+++ b/backend/tissue-security/build.gradle
@@ -7,10 +7,6 @@ dependencies {
 
   implementation libs.spring.boot.starter.oauth2.resource.server
 
-  implementation libs.jjwt.api
-  runtimeOnly libs.jjwt.impl
-  runtimeOnly libs.jjwt.jackson
-
   implementation libs.spring.boot.starter.data.redis
 }
 

--- a/backend/tissue-security/src/main/java/com/tissue/security/config/SecurityConfig.java
+++ b/backend/tissue-security/src/main/java/com/tissue/security/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.tissue.security.config;
 
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.tissue.security.domain.TokenProvider;
 import com.tissue.security.domain.TokenType;
 import com.tissue.security.handler.ApiAccessDeniedHandler;
@@ -34,8 +37,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -62,19 +67,11 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    /**
-     * System-role hierarchy so {@code hasRole('ADMIN')} (used by {@code @RequireSystemAdmin}) also
-     * admits {@code SUPER_ADMIN}. {@code hasRole} otherwise matches the exact {@code ROLE_ADMIN}.
-     */
     @Bean
     static RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl.fromHierarchy("ROLE_SUPER_ADMIN > ROLE_ADMIN\nROLE_ADMIN > ROLE_USER");
     }
 
-    /**
-     * Wires the {@link RoleHierarchy} into method-security SpEL ({@code @PreAuthorize}); a plain
-     * {@code RoleHierarchy} bean is not applied to method security automatically.
-     */
     @Bean
     static MethodSecurityExpressionHandler methodSecurityExpressionHandler(RoleHierarchy roleHierarchy) {
         DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
@@ -84,10 +81,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtDecoder jwtDecoder() {
-        String secret = tissueSecurityProperties.getJwt().getSecret();
-        SecretKeySpec secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
-
-        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey).build();
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(hmacKey()).build();
 
         OAuth2TokenValidator<Jwt> validator = JwtValidators.createDefaultWithIssuer(TokenProvider.ISSUER);
         decoder.setJwtValidator(validator);
@@ -95,8 +89,19 @@ public class SecurityConfig {
         return decoder;
     }
 
+    @Bean
+    public JwtEncoder jwtEncoder() {
+        JWKSource<SecurityContext> jwkSource = new ImmutableSecret<>(hmacKey());
+        return new NimbusJwtEncoder(jwkSource);
+    }
+
+    private SecretKeySpec hmacKey() {
+        String secret = tissueSecurityProperties.getJwt().getSecret();
+        return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
     /**
-     * Reconstructs MemberDetails from JWT.
+     * Reconstructs MemberDetails from JWT
      */
     @Bean
     public Converter<Jwt, AbstractAuthenticationToken> jwtAuthenticationConverter() {

--- a/backend/tissue-security/src/main/java/com/tissue/security/jwt/JwtTokenProvider.java
+++ b/backend/tissue-security/src/main/java/com/tissue/security/jwt/JwtTokenProvider.java
@@ -4,24 +4,25 @@ import com.tissue.security.config.TissueSecurityProperties;
 import com.tissue.security.domain.TokenProvider;
 import com.tissue.security.domain.TokenType;
 import com.tissue.security.domain.exception.TokenExpiredException;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtBuilder;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -30,11 +31,13 @@ public class JwtTokenProvider implements TokenProvider {
 
     public static final int SECRET_KEY_LENGTH = 32;
 
-    private final SecretKey secretKey;
+    private final JwtEncoder jwtEncoder;
+    private final JwtDecoder jwtDecoder;
     private final Duration accessTokenValidity;
     private final Duration refreshTokenValidity;
 
-    public JwtTokenProvider(TissueSecurityProperties tissueSecurityProperties) {
+    public JwtTokenProvider(
+            TissueSecurityProperties tissueSecurityProperties, JwtEncoder jwtEncoder, JwtDecoder jwtDecoder) {
         TissueSecurityProperties.Jwt jwt = tissueSecurityProperties.getJwt();
         String secret = jwt.getSecret();
 
@@ -42,7 +45,8 @@ public class JwtTokenProvider implements TokenProvider {
             throw new IllegalStateException("JWT secret must be at least " + SECRET_KEY_LENGTH + " bytes (UTF-8).");
         }
 
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.jwtEncoder = jwtEncoder;
+        this.jwtDecoder = jwtDecoder;
         this.accessTokenValidity = jwt.getAccessTokenValidity();
         this.refreshTokenValidity = jwt.getRefreshTokenValidity();
     }
@@ -72,9 +76,13 @@ public class JwtTokenProvider implements TokenProvider {
 
     @Override
     public Long validateRefreshTokenAndGetMemberId(String token) {
-        Claims claims = parseAndValidateClaims(token);
-        validateTokenType(claims, TokenType.REFRESH);
-        return claims.get(CLAIM_MEMBER_ID, Long.class);
+        Jwt jwt = decode(token);
+
+        if (!Objects.equals(TokenType.REFRESH.getValue(), jwt.getClaimAsString(CLAIM_TOKEN_TYPE))) {
+            throw new JwtTokenException();
+        }
+
+        return Long.parseLong(jwt.getSubject());
     }
 
     private String createToken(
@@ -84,52 +92,50 @@ public class JwtTokenProvider implements TokenProvider {
             @Nullable String email,
             String username,
             Collection<? extends GrantedAuthority> authorities) {
+        Instant now = Instant.now();
+        List<String> roles =
+                authorities.stream().map(GrantedAuthority::getAuthority).toList();
+
+        JwtClaimsSet.Builder claims = JwtClaimsSet.builder()
+                .subject(String.valueOf(memberId))
+                .issuer(TokenProvider.ISSUER)
+                .issuedAt(now)
+                .expiresAt(now.plus(validity))
+                .claim(CLAIM_TOKEN_TYPE, tokenType.getValue())
+                .claim(CLAIM_MEMBER_ID, memberId)
+                .claim(CLAIM_USERNAME, username)
+                .claim(CLAIM_AUTHORITIES, roles);
+
+        if (email != null) {
+            claims.claim(CLAIM_EMAIL, email);
+        }
+        if (tokenType == TokenType.REFRESH) {
+            claims.id(UUID.randomUUID().toString());
+        }
+
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+
         try {
-            Instant now = Instant.now();
-            List<String> roles =
-                    authorities.stream().map(GrantedAuthority::getAuthority).toList();
+            return jwtEncoder
+                    .encode(JwtEncoderParameters.from(header, claims.build()))
+                    .getTokenValue();
+        } catch (JwtException e) {
+            throw new JwtTokenException();
+        }
+    }
 
-            JwtBuilder builder = Jwts.builder()
-                    .subject(String.valueOf(memberId))
-                    .issuedAt(Date.from(now))
-                    .expiration(Date.from(now.plus(validity)))
-                    .issuer(TokenProvider.ISSUER)
-                    .claim(CLAIM_TOKEN_TYPE, tokenType.getValue())
-                    .claim(CLAIM_MEMBER_ID, memberId)
-                    .claim(CLAIM_EMAIL, email)
-                    .claim(CLAIM_USERNAME, username)
-                    .claim(CLAIM_AUTHORITIES, roles)
-                    .signWith(secretKey, Jwts.SIG.HS256);
-
-            if (tokenType == TokenType.REFRESH) {
-                builder.id(UUID.randomUUID().toString());
+    private Jwt decode(String token) {
+        try {
+            return jwtDecoder.decode(token);
+        } catch (JwtValidationException e) {
+            boolean expired = e.getErrors().stream()
+                    .anyMatch(error -> error.getDescription() != null
+                            && error.getDescription().toLowerCase().contains("expired"));
+            if (expired) {
+                throw new TokenExpiredException();
             }
-
-            return builder.compact();
-
-        } catch (JwtException | IllegalArgumentException e) {
             throw new JwtTokenException();
-        }
-    }
-
-    private void validateTokenType(Claims claims, TokenType expectedType) {
-        TokenType tokenType = TokenType.from(claims.get(CLAIM_TOKEN_TYPE, String.class));
-        if (!Objects.equals(expectedType, tokenType)) {
-            throw new JwtTokenException();
-        }
-    }
-
-    private Claims parseAndValidateClaims(String token) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload();
-
-        } catch (ExpiredJwtException e) {
-            throw new TokenExpiredException();
-        } catch (JwtException | SecurityException | IllegalArgumentException e) {
+        } catch (JwtException e) {
             throw new JwtTokenException();
         }
     }

--- a/backend/tissue-security/src/test/java/com/tissue/security/jwt/JwtTokenProviderTest.java
+++ b/backend/tissue-security/src/test/java/com/tissue/security/jwt/JwtTokenProviderTest.java
@@ -3,19 +3,27 @@ package com.tissue.security.jwt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import com.tissue.security.config.TissueSecurityProperties;
 import com.tissue.security.domain.exception.TokenExpiredException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
-import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
 class JwtTokenProviderTest {
 
@@ -26,12 +34,39 @@ class JwtTokenProviderTest {
 
     private final JwtTokenProvider tokenProvider = createTokenProvider();
 
+    private static SecretKeySpec key(String secret) {
+        return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    private static JwtEncoder encoder(String secret) {
+        return new NimbusJwtEncoder(new ImmutableSecret<>(key(secret)));
+    }
+
+    private static JwtDecoder decoder(String secret) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(key(secret)).build();
+        decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer("TISSUE"));
+        return decoder;
+    }
+
     private static JwtTokenProvider createTokenProvider() {
         TissueSecurityProperties properties = new TissueSecurityProperties();
         properties.getJwt().setSecret(SECRET);
         properties.getJwt().setAccessTokenValidity(Duration.ofHours(1));
         properties.getJwt().setRefreshTokenValidity(Duration.ofDays(7));
-        return new JwtTokenProvider(properties);
+        return new JwtTokenProvider(properties, encoder(SECRET), decoder(SECRET));
+    }
+
+    private static String signedRefreshToken(String secret, Instant issuedAt, Instant expiresAt) {
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(String.valueOf(MEMBER_ID))
+                .issuer("TISSUE")
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("tokenType", "refresh")
+                .claim("memberId", MEMBER_ID)
+                .build();
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+        return encoder(secret).encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
     }
 
     @Nested
@@ -87,16 +122,8 @@ class JwtTokenProviderTest {
         @DisplayName("fail: if refresh token is expired, validation throws TokenExpiredException")
         void failRefreshTokenValidation_If_ExpiredToken() {
             // given
-            SecretKey secretKey = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
-            String expiredToken = Jwts.builder()
-                    .subject(String.valueOf(MEMBER_ID))
-                    .issuedAt(Date.from(java.time.Instant.now().minusSeconds(3600)))
-                    .expiration(Date.from(java.time.Instant.now().minusSeconds(1)))
-                    .issuer("TISSUE")
-                    .claim("tokenType", "refresh")
-                    .claim("memberId", MEMBER_ID)
-                    .signWith(secretKey)
-                    .compact();
+            Instant now = Instant.now();
+            String expiredToken = signedRefreshToken(SECRET, now.minusSeconds(7200), now.minusSeconds(3600));
 
             // when & then
             assertThatThrownBy(() -> tokenProvider.validateRefreshTokenAndGetMemberId(expiredToken))
@@ -107,18 +134,8 @@ class JwtTokenProviderTest {
         @DisplayName("fail: if token signature is invalid, validation throws JwtTokenException")
         void failRefreshTokenValidation_If_InvalidSignature() {
             // given
-            String wrongSecret = "x".repeat(32);
-            SecretKey wrongKey = Keys.hmacShaKeyFor(wrongSecret.getBytes(StandardCharsets.UTF_8));
-
-            String tamperedToken = Jwts.builder()
-                    .subject(String.valueOf(MEMBER_ID))
-                    .issuedAt(Date.from(java.time.Instant.now()))
-                    .expiration(Date.from(java.time.Instant.now().plusSeconds(3600)))
-                    .issuer("TISSUE")
-                    .claim("tokenType", "refresh")
-                    .claim("memberId", MEMBER_ID)
-                    .signWith(wrongKey)
-                    .compact();
+            Instant now = Instant.now();
+            String tamperedToken = signedRefreshToken("x".repeat(32), now, now.plusSeconds(3600));
 
             // when & then
             assertThatThrownBy(() -> tokenProvider.validateRefreshTokenAndGetMemberId(tamperedToken))
@@ -132,10 +149,10 @@ class JwtTokenProviderTest {
         // given
         TissueSecurityProperties properties = new TissueSecurityProperties();
         String shortSecret = "a".repeat(31);
-
         properties.getJwt().setSecret(shortSecret);
 
         // when & then
-        assertThatThrownBy(() -> new JwtTokenProvider(properties)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> new JwtTokenProvider(properties, encoder(SECRET), decoder(SECRET)))
+                .isInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change.
Describe migration if needed for breaking changes.
-->
- remove jjwt dependency and use nimbus (oauth2-resource-server)

## Type of change (Check all)

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change (Change that causes existing functionality to not work as expected)
- [x] Refactoring (No functional changes, no api changes)
- [ ] Documentation update

## How Has This Been Tested?

<!--
Please choose the tests that you ran to verify your changes.
-->

- [x] Unit Test
- [x] Integration Test
- [ ] E2E Test
- [ ] Manual Test

## Screenshots (Optional)

<!--
Attach screenshots or demo recordings for TUI changes, benchmarks, logs, etc...
-->

## Related Issues or Links

<!--
Please link to the issue here:
- Closes # (issue number)
- [link](link)
-->
